### PR TITLE
Fix for a mix of issues and bugs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/benchmark/condensed/BooleanCondensed.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/condensed/BooleanCondensed.java
@@ -86,7 +86,7 @@ public class BooleanCondensed extends BooleanValue {
         content.append(key.toString());
         content.append("</td><td>");
         if (detected.isNumeralDetected()) {
-            content.append("-</td><td>-</td><td>-</td><td>-</td><td>");
+            content.append("</td><td></td><td></td><td></td><td>");
         }
         content.append(Integer.toString(this.passed));
         content.append("</td><td>");

--- a/src/main/java/org/jenkinsci/plugins/benchmark/condensed/StringCondensed.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/condensed/StringCondensed.java
@@ -88,7 +88,7 @@ public class StringCondensed extends StringValue {
         content.append(key.toString());
         content.append("</td><td>");
         if (detected.isNumeralDetected()) {
-            content.append("-</td><td>-</td><td>-</td><td>-</td><td>");
+            content.append("</td><td></td><td></td><td></td><td>");
         }
         content.append(Integer.toString(this.passed));
         content.append("</td><td>");

--- a/src/main/java/org/jenkinsci/plugins/benchmark/parsers/MapperBase.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/parsers/MapperBase.java
@@ -225,7 +225,7 @@ public class MapperBase {
                     }
                 }
                 if (!detectedParam) {
-                    results.put(baseParam.getKey(), baseParam.getValue());
+                    parameters.put(baseParam.getKey(), baseParam.getValue());
                 }
             }
             for (Map.Entry<Integer, TestGroup> baseFile : mapper.getFiles().entrySet()) {

--- a/src/main/java/org/jenkinsci/plugins/benchmark/results/BooleanValue.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/results/BooleanValue.java
@@ -157,7 +157,7 @@ public class BooleanValue extends TestValue {
         if (value == null) {
             return "";
         } else {
-            return value.toString();
+            return "__boolean__";
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/benchmark/results/TestValue.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/results/TestValue.java
@@ -991,17 +991,17 @@ public class TestValue extends TestGroup {
         for (int build = builds.last(); build >= builds.first(); build--) {
             String value = this.getValueAsLocaleString(build, decimalSeparator);
             if (value.isEmpty()) {
-                content.append("</td><td>-");
+                content.append("</td><td>");
             } else {
                 Boolean failedState = this.getFailedState(build);
                 if (failedState == null){
                     content.append("</td><td>");
-                    content.append(value);
+                    if (!value.equals("__boolean__")) content.append(value);
                 } else {
                     content.append("</td><td style=\"background-color:");
                     content.append(this.getColor(failedState));
-                    content.append(";\">");
-                    content.append(value);
+                    content.append("\">");
+                    if (!value.equals("__boolean__")) content.append(value);
                     if (failedState){
                         listNFailed.set(index, listNFailed.get(index) + 1);
                     } else {

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/core/BenchmarkProjectAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/core/BenchmarkProjectAction/index.jelly
@@ -253,20 +253,24 @@
         }
         .hover td:first-child {
           background-color:#ededed;
+          text-align: left;
         }
         <j:if test="${it.NumberOfHeads > 1}">
           .hover td:nth-child(2) {
             background-color:#ededed;
+            text-align: left;
           }
         </j:if>
         <j:if test="${it.NumberOfHeads > 2}">
           .hover td:nth-child(3) {
             background-color:#ededed;
+            text-align: left;
           }
         </j:if>
         <j:if test="${it.NumberOfHeads > 3}">
           .hover td:nth-child(4) {
             background-color:#ededed;
+            text-align: left;
           }
         </j:if>
         #api_link {


### PR DESCRIPTION
Remove hyphens from the main tables to allow numerical sorting.
Remove text versions (true/false) of Boolean results from the raw table to allow numerical sorting.
Fix bug that occurred when changing schema content where old parameters ended as results and crashed the display of the main tables.
Adjusted left the Group/Result/Unit names for readability and prevent the awkward display.